### PR TITLE
Minimum changes needed to support GHE in this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Build Status](https://cloud.drone.io/api/badges/meltwater/drone-convert-pathschanged/status.svg)](https://cloud.drone.io/meltwater/drone-convert-pathschanged)
-[![Docker Pulls](https://img.shields.io/docker/pulls/meltwater/drone-convert-pathschanged)](https://hub.docker.com/r/meltwater/drone-convert-pathschanged)
-
 A [Drone](https://drone.io/) [conversion extension](https://docs.drone.io/extensions/conversion/) to include/exclude pipelines and steps based on paths changed.
 
 _Please note this project requires Drone server version 1.4 or higher._

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ type spec struct {
 	Secret string `envconfig:"DRONE_SECRET"`
 
 	Provider         string `envconfig:"PROVIDER"`
+	ProviderURI		 string `envconfig:"PROVIDER_URI"`
 	Token            string `envconfig:"TOKEN"`
 	BitBucketAddress string `envconfig:"BB_ADDRESS"`
 }
@@ -77,6 +78,7 @@ func main() {
 		plugin.New(
 			spec.Token,
 			spec.Provider,
+			spec.ProviderURI,
 		),
 		spec.Secret,
 		logrus.StandardLogger(),

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -23,6 +23,7 @@ type (
 	plugin struct {
 		token            string
 		provider         string
+		providerURI 	 string
 		bitbucketAddress string
 	}
 
@@ -81,10 +82,11 @@ func marshal(in []*resource) ([]byte, error) {
 }
 
 // New returns a new conversion plugin.
-func New(token string, provider string) converter.Plugin {
+func New(token string, provider string, uri string) converter.Plugin {
 	return &plugin{
 		token:    token,
 		provider: provider,
+		providerURI: uri,
 	}
 }
 
@@ -125,7 +127,11 @@ func (p *plugin) Convert(ctx context.Context, req *converter.Request) (*drone.Co
 
 		switch p.provider {
 		case "github":
-			changedFiles, err = providers.GetGithubFilesChanged(req.Repo, req.Build, p.token)
+			if p.providerURI != "" {
+				changedFiles, err = providers.GetGithubEnterpriseFilesChanged(req.Repo, req.Build, p.token, p.providerURI)
+			} else {
+				changedFiles, err = providers.GetGithubFilesChanged(req.Repo, req.Build, p.token)
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -34,7 +34,7 @@ func TestNewEmptyPipeline(t *testing.T) {
 	}
 
 	for _, provider := range providers {
-		plugin := New("invalidtoken", provider)
+		plugin := New("invalidtoken", provider, "")
 
 		config, err := plugin.Convert(noContext, req)
 		if err != nil {
@@ -73,7 +73,7 @@ this_is_invalid_yaml
 		},
 	}
 
-	plugin := New("invalidtoken", "")
+	plugin := New("invalidtoken", "", "")
 
 	_, err := plugin.Convert(noContext, req)
 	if err == nil {
@@ -115,7 +115,7 @@ steps:
 		},
 	}
 
-	plugin := New("invalidtoken", "unsupported")
+	plugin := New("invalidtoken", "unsupported", "")
 
 	_, err := plugin.Convert(noContext, req)
 	if err == nil {
@@ -163,7 +163,7 @@ steps:
 		},
 	}
 
-	plugin := New("invalidtoken", "github")
+	plugin := New("invalidtoken", "github", "")
 
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {
@@ -236,7 +236,7 @@ steps:
 		},
 	}
 
-	plugin := New("invalidtoken", "github")
+	plugin := New("invalidtoken", "github", "")
 
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {
@@ -306,7 +306,7 @@ steps:
 		},
 	}
 
-	plugin := New("invalidtoken", "github")
+	plugin := New("invalidtoken", "github", "")
 
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {
@@ -379,7 +379,7 @@ steps:
 		},
 	}
 
-	plugin := New("invalidtoken", "github")
+	plugin := New("invalidtoken", "github", "")
 
 	config, err := plugin.Convert(noContext, req)
 	if err != nil {


### PR DESCRIPTION
This plugin, as authored by the upstream project, implements the [Drone Conversion Extension](https://docs.drone.io/extensions/conversion/) and makes use of the drone project's plugin framework as well as drone's scm library.  The function this plugin performs is to enable conditional execution of steps or pipelines based on whether individual files or directories in a repo changed.

However, despite being based on drone's scm library, the extension only supports Github and Bitbucket, but none of the other backends the library can interface with.  Specifically, for this plugin to be useful to us, we need Github Enterprise.  This changeset is the bare minimum changeset to enable Github Enterprise in addition to the other backends already supported by the extension.

A new docker container was built and published in ECR at 906087756158.dkr.ecr.us-east-1.amazonaws.com/drone-convert-pathschanged:latest, then deployed onto ghe-drone.  A test repo was created and verified to work as expected, but I forgot to take screenshots for proof :/ .  The extension is active on ghe-drone, though, and can be used.